### PR TITLE
Tweaks plus fixes to build static library on linux

### DIFF
--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -7,6 +7,8 @@ enable_testing()
 set(WARNINGS)
 set(ANDROID_STL_FLAGS)
 
+option(LIB_TYPE "Library type - STATIC/SHARED" SHARED)
+
 # Platform (not compiler) specific settings
 if(IOS)
   set(IOS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../Build_iOS")
@@ -89,9 +91,14 @@ elseif(UNIX) # This includes OSX
   
   option(BUILD_SHARED_LIBS "Build shared Libraries." ON)
   
-  # Prefer the homebrew version of zlib
-  find_library(ZLIB_LIBRARIES NAMES libz.a PATHS /usr/local/Cellar/zlib/1.2.8/lib NO_DEFAULT_PATH)
-  find_path(ZLIB_INCLUDE_DIRS NAMES zlib.h PATHS /usr/local/Cellar/zlib/1.2.8/include NO_DEFAULT_PATH)
+  if(NOT APPLE)
+    find_library(ZLIB_LIBRARIES NAMES libz.a)
+    find_path(ZLIB_INCLUDE_DIRS NAMES zlib.h)
+  else()
+    # Prefer the homebrew version of zlib
+    find_library(ZLIB_LIBRARIES NAMES libz.a PATHS /usr/local/Cellar/zlib/1.2.8/lib NO_DEFAULT_PATH)
+    find_path(ZLIB_INCLUDE_DIRS NAMES zlib.h PATHS /usr/local/Cellar/zlib/1.2.8/include NO_DEFAULT_PATH)
+  endif()
   
   if(NOT ZLIB_LIBRARIES OR NOT ZLIB_INCLUDE_DIRS)
     find_package(ZLib)
@@ -152,11 +159,11 @@ if(ANDROID)
 elseif((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR IOS)
   message("-- Setting clang options")
 
-  set(WARNINGS "-Wall -Wextra -Wcast-qual -Wconversion -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wpacked -Wredundant-decls")
+  #set(WARNINGS "-Wall -Wextra -Wcast-qual -Wconversion -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wpacked -Wredundant-decls")
   set(OSX_SUPPRESSIONS "-Wno-overloaded-virtual -Wno-sign-conversion -Wno-deprecated -Wno-unknown-pragmas -Wno-reorder -Wno-char-subscripts -Wno-switch -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated -Wno-unused-value -Wno-unknown-warning-option -Wno-return-type-c-linkage -Wno-unused-function -Wno-sign-compare -Wno-shorten-64-to-32 -Wno-reorder -Wno-unused-local-typedefs")
   set(WARNINGS "${WARNINGS} ${OSX_SUPPRESSIONS}")
 
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wno-return-type-c-linkage -Wno-unneeded-internal-declaration")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-return-type-c-linkage -Wno-unneeded-internal-declaration")
   set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
   set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
 
@@ -164,7 +171,7 @@ elseif((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR IOS)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   message("-- Setting gcc options")
 
-  set(WARNINGS "-Wall -Wextra -Wunused-parameter -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wpacked -Wredundant-decls -Wunreachable-code")
+  set(WARNINGS "-Wall -Wextra -Wunused-parameter -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wpacked -Wredundant-decls -Wunreachable-code -Wno-reorder -Wno-overloaded-virtual -Wno-sign-conversion -Wno-deprecated -Wno-unknown-pragmas -Wno-reorder -Wno-char-subscripts -Wno-switch -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated -Wno-unused-value -Wno-unknown-warning-option -Wno-return-type-c-linkage -Wno-unused-function -Wno-sign-compare -Wdeprecated-declarations -Wno-shorten-64-to-32 -Wno-reorder -Wno-unused-local-typedefs")
 
   set(LD_FLAGS "${LD_FLAGS} -Wl,-z,defs")
 

--- a/Release/Dockerfile
+++ b/Release/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:16.04
+
+RUN apt-get -y update
+RUN apt-get -y install cmake build-essential g++ wget git clang
+RUN apt-get -y install libboost-all-dev uuid-dev
+RUN apt-get -y install libssl-dev libjansson-dev automake pkg-config doxygen autoconf llvm check libtool make

--- a/Release/include/cpprest/details/x509_cert_utilities.h
+++ b/Release/include/cpprest/details/x509_cert_utilities.h
@@ -28,8 +28,6 @@
 #include <vector>
 #include <string>
 
-#if defined(__APPLE__) || (defined(ANDROID) || defined(__ANDROID__)) || (defined(_WIN32)  && !defined(__cplusplus_winrt) && !defined(_M_ARM) && !defined(CPPREST_EXCLUDE_WEBSOCKETS))
-
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4005)
@@ -50,6 +48,7 @@ namespace web { namespace http { namespace client { namespace details {
 
 using namespace utility;
 
+#if defined(__APPLE__) || (defined(ANDROID) || defined(__ANDROID__)) || (defined(_WIN32)  && !defined(__cplusplus_winrt) && !defined(_M_ARM) && !defined(CPPREST_EXCLUDE_WEBSOCKETS))
 
 /// <summary>
 /// Using platform specific APIs verifies server certificate.
@@ -61,6 +60,8 @@ using namespace utility;
 bool verify_cert_chain_platform_specific(boost::asio::ssl::verify_context &verifyCtx, const std::string &hostName);
 
 bool verify_X509_cert_chain(const std::vector<std::string> &certChain, const std::string &hostName);
+
+#endif
 
 using PinningCallBackFunction = std::function<bool(const std::string&, const std::string&)>;
 using RejectedCertsCallback = std::function<void(json::value)>;
@@ -77,4 +78,4 @@ utility::string_t get_issuer_from_cert(X509* cert);
 
 }}}}
 
-#endif
+

--- a/Release/src/CMakeLists.txt
+++ b/Release/src/CMakeLists.txt
@@ -81,7 +81,7 @@ elseif(WIN32)
   endif()
 endif()
 
-add_library(${Casablanca_LIBRARY} ${SOURCES})
+add_library(${Casablanca_LIBRARY} ${LIB_TYPE} ${SOURCES})
 
 target_link_libraries(${Casablanca_LIBRARY}
   ${CMAKE_THREAD_LIBS_INIT}

--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -1326,7 +1326,7 @@ private:
                     else
                     {
 
-                        writeBuffer.putn(&decompressed[0], decompressed.size())
+                        writeBuffer.putn_nocopy(&decompressed[0], decompressed.size())
                             .then([this_request, to_read](pplx::task<size_t> op)
                         {
                             try
@@ -1435,7 +1435,7 @@ private:
                 }
                 else
                 {
-                    writeBuffer.putn(&decompressed[0], decompressed.size())
+                    writeBuffer.putn_nocopy(&decompressed[0], decompressed.size())
                         .then([this_request, read_size](pplx::task<size_t> op)
                     {
                         size_t writtenSize = 0;

--- a/Release/src/http/client/x509_cert_utilities.cpp
+++ b/Release/src/http/client/x509_cert_utilities.cpp
@@ -86,6 +86,8 @@ bool verify_cert_chain_platform_specific(boost::asio::ssl::verify_context &verif
     return verify_result;
 }
 
+#endif
+
 std::string get_public_key_from_cert(X509* cert)
 {
     std::string result;
@@ -268,7 +270,5 @@ utility::string_t get_issuer_from_cert(X509* cert)
 
     return utility::conversions::to_string_t(buffer);
 }
-
-#endif
 
 }}}}


### PR DESCRIPTION
For building use with following flags:
    cmake -DBUILD_TESTS=OFF -DBUILD_SAMPLES=OFF -DLIB_TYPE=STATIC ..

Release Dockerfile contains ubuntu environment

Clang wont work due to ubuntu xenial bug
