### PR TITLE
Change cert pinning callback to retrun the full chain.

### DIFF
--- a/Release/include/cpprest/details/http_client_impl.h
+++ b/Release/include/cpprest/details/http_client_impl.h
@@ -197,7 +197,7 @@ public:
     // Registration for cancellation notification if enabled.
     pplx::cancellation_token_registration m_cancellationRegistration;
 
-    bool m_certificate_pinning_failed{ false };
+    bool m_certificate_chain_verification_failed{ false };
 
 protected:
 

--- a/Release/include/cpprest/details/x509_cert_utilities.h
+++ b/Release/include/cpprest/details/x509_cert_utilities.h
@@ -52,6 +52,8 @@ using namespace utility;
 
 #ifndef __linux__
 
+bool is_end_certificate_in_chain(boost::asio::ssl::verify_context &verifyCtx);
+
 /// <summary>
 /// Using platform specific APIs verifies server certificate.
 /// Currently implemented to work on iOS, Android, and OS X.
@@ -65,18 +67,7 @@ bool verify_X509_cert_chain(const std::vector<std::string> &certChain, const std
 
 #endif
 
-using PinningCallBackFunction = std::function<bool(const std::string&, const std::string&)>;
-using RejectedCertsCallback = std::function<void(json::value)>;
-
-bool is_certificate_pinned(const std::string& host, boost::asio::ssl::verify_context &verifyCtx, PinningCallBackFunction pinningCallback, RejectedCertsCallback rejectedCertsCallback = nullptr);
-
-json::value get_cert_chain_information(boost::asio::ssl::verify_context &verifyCtx);
-
-utility::string_t get_fingerprint_from_cert(const X509* cert);
-
-utility::string_t get_subject_from_cert(X509* cert);
-
-utility::string_t get_issuer_from_cert(X509* cert);
+std::vector<std::vector<unsigned char>> get_X509_cert_chain_encoded_data(boost::asio::ssl::verify_context &verifyCtx);
 
 }}}}
 

--- a/Release/include/cpprest/http_client.h
+++ b/Release/include/cpprest/http_client.h
@@ -84,7 +84,7 @@ namespace client
 using web::credentials;
 using web::web_proxy;
 
-using PinningCallBackFunction = std::function<bool(const utility::string_t&, const utility::string_t&)>;
+using CertificateChainCallBackFunction = std::function<bool(const utility::string_t&, const std::vector<std::vector<unsigned char>>&)>;
 
 /// <summary>
 /// HTTP client configuration class, used to set the possible configuration options
@@ -101,7 +101,7 @@ public:
 #if !defined(__cplusplus_winrt)
         , m_validate_certificates(true)
 #endif
-		, m_certificate_pinning_callback([](const utility::string_t&, const utility::string_t&)->bool { return true; }) // by default certificate pinning returns success
+        , m_certificate_chain_callback([](const utility::string_t&, const std::vector<std::vector<unsigned char>>&)->bool { return true; })  // by default certificate chain callback returns success.
 		, m_set_user_nativehandle_options([](native_handle)->void {})
 #if !defined(_WIN32) && !defined(__cplusplus_winrt)
         , m_ssl_context_callback([](boost::asio::ssl::context&)->void{})
@@ -345,7 +345,7 @@ public:
     /// <param name="callback">A user callback allowing for customization of the request</param>
     void set_nativehandle_options(const std::function<void(native_handle)> &callback)
     {
-         m_set_user_nativehandle_options = callback;
+        m_set_user_nativehandle_options = callback;
     }
 
     /// <summary>
@@ -357,25 +357,25 @@ public:
         m_set_user_nativehandle_options(handle);
     }
 
-	/// <summary>
-	/// Set the certificate pinning callback. If set, HTTP client will call this callback in a blocking manner during HTTP connection.
-	/// </summary>
-	void set_user_certificate_pinning_callback(const PinningCallBackFunction& callback)
-	{
-		m_certificate_pinning_callback = callback;
-	}
 
-	/// <summary>
-	/// Invokes the certificate pinning callback.
-	/// </summary>
-	/// <param name="url">The URL in the actual TLS session which might be different than the original URL due to redirection.</param>
-	/// <param name="certificate">The public key of one of the certificate in the chain presented to the consumer for validation purposes.</param>
-	/// <returns>True if the consumer code validated the certificate, false otherwise. False will terminate the HTTP connection.</returns>
-	bool invoke_pinning_callback(const utility::string_t& url, const utility::string_t& public_key) const
-	{
-		return m_certificate_pinning_callback(url, public_key);
-	}
+    /// <summary>
+    /// Set the certificate chain callback. If set, HTTP client will call this callback in a blocking manner during HTTP connection.
+    /// </summary>
+    void set_user_certificate_chain_callback(const CertificateChainCallBackFunction& callback)
+    {
+        m_certificate_chain_callback = callback;
+    }
 
+    /// <summary>
+    /// Invokes the certificate chain callback.
+    /// </summary>
+    /// <param name="url">The URL in the actual TLS session which might be different than the original URL due to redirection.</param>
+    /// <param name="certificate">The cert_chain is the encoded data of the certificate chain, used by the client for validation purposes however it wants.</param>
+    /// <returns>True if the consumer code allows the connection, false otherwise. False will terminate the HTTP connection.</returns>
+    bool invoke_certificate_chain_callback(const utility::string_t& url, const std::vector<std::vector<unsigned char>>& cert_chain) const
+    {
+        return m_certificate_chain_callback(url, cert_chain);
+    }
 
 #if !defined(_WIN32) && !defined(__cplusplus_winrt)
     /// <summary>
@@ -435,7 +435,7 @@ private:
     bool m_validate_certificates;
 #endif
 
-	PinningCallBackFunction m_certificate_pinning_callback;
+    CertificateChainCallBackFunction m_certificate_chain_callback;
     std::function<void(native_handle)> m_set_user_nativehandle_options;
 
 #if !defined(_WIN32) && !defined(__cplusplus_winrt)

--- a/Release/src/http/client/x509_cert_utilities.cpp
+++ b/Release/src/http/client/x509_cert_utilities.cpp
@@ -35,15 +35,25 @@ namespace web { namespace http { namespace client { namespace details {
 
 #ifndef __linux__
 
-bool verify_cert_chain_platform_specific(boost::asio::ssl::verify_context &verifyCtx, const std::string &hostName)
+bool is_end_certificate_in_chain(boost::asio::ssl::verify_context &verifyCtx)
 {
     X509_STORE_CTX *storeContext = verifyCtx.native_handle();
     int currentDepth = X509_STORE_CTX_get_error_depth(storeContext);
     if (currentDepth != 0)
     {
+        return false;
+    }
+    return true;
+}
+
+bool verify_cert_chain_platform_specific(boost::asio::ssl::verify_context &verifyCtx, const std::string &hostName)
+{
+    if (!is_end_certificate_in_chain(verifyCtx))
+    {
         return true;
     }
 
+    X509_STORE_CTX *storeContext = verifyCtx.native_handle();
     STACK_OF(X509) *certStack = X509_STORE_CTX_get_chain(storeContext);
     const int numCerts = sk_X509_num(certStack);
     if (numCerts < 0)
@@ -91,71 +101,10 @@ bool verify_cert_chain_platform_specific(boost::asio::ssl::verify_context &verif
 
 #endif
 
-std::string get_public_key_from_cert(X509* cert)
+std::vector<std::vector<unsigned char>> get_X509_cert_chain_encoded_data(boost::asio::ssl::verify_context &verifyCtx)
 {
-    std::string result;
+    std::vector<std::vector<unsigned char>> cert_chain;
 
-    EVP_PKEY *pKey =  X509_get_pubkey(cert);
-    
-    if(!pKey)
-    {
-        return result;
-    }
-
-    std::size_t keyLen = i2d_PublicKey(pKey, NULL);
-
-    if(keyLen > 0)
-    {
-        std::vector<unsigned char> buf(keyLen, 0x00);
-
-        unsigned char *buffer = &buf[0];
-
-        i2d_PublicKey(pKey, &buffer);
-
-        std::stringstream ssResult;
-
-        ssResult << std::hex;
-
-        for(auto value: buf)
-        {
-            ssResult << std::setw(2) << std::setfill('0') << (int) (value);
-        }
-
-        result = ssResult.str();
-    }
-
-    EVP_PKEY_free(pKey);
-
-    return result; 
-}
-
-std::vector<std::string> get_cert_chain_public_keys(boost::asio::ssl::verify_context &verifyCtx)
-{
-    std::vector<std::string> certChain;
- 
-    X509_STORE_CTX *storeContext = verifyCtx.native_handle();
-    
-    STACK_OF(X509) *certStack = X509_STORE_CTX_get_chain(storeContext);
-    const int numCerts = sk_X509_num(certStack);
-    if (numCerts < 0)
-    {
-        return certChain;
-    }
-    
-    certChain.reserve(numCerts);
-
-    for (int i = 0; i < numCerts; ++i)
-    {
-        X509 *cert = sk_X509_value(certStack, i);
-        
-        certChain.push_back(get_public_key_from_cert(cert));
-    }
-    
-    return certChain;
-}
-
-json::value get_cert_chain_information(boost::asio::ssl::verify_context &verifyCtx)
-{
     X509_STORE_CTX *storeContext = verifyCtx.native_handle();
 
     STACK_OF(X509) *certStack = X509_STORE_CTX_get_chain(storeContext);
@@ -163,115 +112,27 @@ json::value get_cert_chain_information(boost::asio::ssl::verify_context &verifyC
     const int numCerts = sk_X509_num(certStack);
     if (numCerts < 0)
     {
-        return {};
+        return cert_chain;
     }
- 
-    json::value certChainInformation;
 
+    cert_chain.reserve(numCerts);
     for (int index = 0; index < numCerts; ++index)
     {
         X509 *cert = sk_X509_value(certStack, index);
-
-        json::value certInformation;
-        certInformation[U("Issuer")] = json::value::string(get_issuer_from_cert(cert));
-        certInformation[U("Subject")] = json::value::string(get_subject_from_cert(cert));
-        certInformation[U("FingerPrint")] = json::value::string(get_fingerprint_from_cert(cert));
-
-        utility::stringstream_t countInfo;
-        countInfo << "Certificate: " << index;
-        certChainInformation[countInfo.str()] = certInformation;
-    }
-    return certChainInformation;
-}
-
-bool is_certificate_pinned(const std::string& host, boost::asio::ssl::verify_context &verifyCtx, PinningCallBackFunction pinningCallback, RejectedCertsCallback certInfoCallback)
-{
-    bool result = false;
-
-    auto cert_chain_public_keys = http::client::details::get_cert_chain_public_keys(verifyCtx);
-
-    if (cert_chain_public_keys.empty())
-    {
-        return pinningCallback(host, "");
-    }
-
-    for (const auto& key : cert_chain_public_keys)
-    {
-        if (pinningCallback(host, key))
+        if (cert)
         {
-            result = true;
+            unsigned char * certKeyOut = nullptr;
+            int resCertificateLength = i2d_X509(cert, &certKeyOut);
+            if (resCertificateLength < 0 || !certKeyOut)
+            {
+                continue;
+            }
 
-            break;
+            std::vector<unsigned char> certOut(certKeyOut, certKeyOut + resCertificateLength);
+            cert_chain.emplace_back(certOut);
         }
     }
-
-    if (!result && certInfoCallback)
-    {
-        certInfoCallback(get_cert_chain_information(verifyCtx));
-    }
-
-    return result;
-}
-
-utility::string_t get_fingerprint_from_cert(const X509* cert)
-{
-    unsigned int size;
-    unsigned char buffer[EVP_MAX_MD_SIZE];
-
-    if (!X509_digest(cert, EVP_sha1(), buffer, &size))
-    {
-        return U("");
-    }
-
-    std::stringstream sah1Result;
-
-    sah1Result << std::hex;
-
-    for (unsigned int index = 0; index < size; ++index)
-    {
-        sah1Result << std::setw(2) << std::setfill('0') << (int)(buffer[index]);
-    }
-
-    auto fPrint = sah1Result.str();
-    return utility::string_t(fPrint.begin(), fPrint.end());
-}
-
-utility::string_t get_subject_from_cert(X509* cert)
-{
-    X509_NAME* sub = X509_get_subject_name(cert);
-
-    if (!sub)
-    {
-        return U("");
-    }
-
-    const char* buffer = X509_NAME_oneline(sub, 0, 0);
-
-    if (!buffer)
-    {
-        return U("");
-    }
-
-    return utility::conversions::to_string_t(buffer);
-}
-
-utility::string_t get_issuer_from_cert(X509* cert)
-{
-    X509_NAME* issuer = X509_get_issuer_name(cert);
-
-    if (!issuer)
-    {
-        return U("");
-    }
-
-    const char* buffer = X509_NAME_oneline(issuer, 0, 0);
-
-    if (!buffer)
-    {
-        return U("");
-    }
-
-    return utility::conversions::to_string_t(buffer);
+    return cert_chain;
 }
 
 #endif

--- a/Release/src/http/client/x509_cert_utilities_win32.cpp
+++ b/Release/src/http/client/x509_cert_utilities_win32.cpp
@@ -93,13 +93,12 @@ bool verify_X509_cert_chain(const std::vector<std::string> &certChain, const std
     }
     chain.reset(chainContext);
 
-    // Check to see if the certificate chain is actually trusted.
-    if (chain->TrustStatus.dwErrorStatus != CERT_TRUST_NO_ERROR)
+    // Check to see if the certificate chain is actually trusted, allow certs where it's revocation status is unknown.
+    if (chain->TrustStatus.dwErrorStatus == CERT_TRUST_NO_ERROR || chain->TrustStatus.dwErrorStatus == CERT_TRUST_REVOCATION_STATUS_UNKNOWN)
     {
-        return false;
+        return true;
     }
-
-    return true;
+    return false;
 }
 
 }}}}

--- a/Release/src/websockets/client/ws_client_wspp.cpp
+++ b/Release/src/websockets/client/ws_client_wspp.cpp
@@ -175,23 +175,6 @@ public:
                 {
                     using namespace web::http::client::details;
 
-                    auto pinningCallback = [this](const std::string& host, const std::string& key) {
-                        return m_config.invoke_pinning_callback(host, key);
-                    };
-
-                    auto rejectedCertsCallback = [this](json::value certChainInfo) {
-                        m_config.invoke_rejected_certs_chain_callback(certChainInfo);
-                    };
-                    
-                    auto host = utility::conversions::to_utf8string(m_uri.host());
-
-                    auto certPinned = is_certificate_pinned(host, verifyCtx, pinningCallback, rejectedCertsCallback);
-
-                    if (!certPinned)
-                    {
-                        return false;
-                    }
-
 #if defined(__APPLE__) || (defined(ANDROID) || defined(__ANDROID__)) || defined(_WIN32)
                     // On OS X, iOS, and Android, OpenSSL doesn't have access to where the OS
                     // stores keychains. If OpenSSL fails we will doing verification at the
@@ -203,11 +186,30 @@ public:
                     }
                     if(m_openssl_failed)
                     {
-                        return http::client::details::verify_cert_chain_platform_specific(verifyCtx, utility::conversions::to_utf8string(m_uri.host()));
+
+                        if (!http::client::details::is_end_certificate_in_chain(verifyCtx))
+                        {
+                            // Continue until we get the end certificate.
+                            return true;
+                        }
+
+                        if (!http::client::details::verify_cert_chain_platform_specific(verifyCtx, utility::conversions::to_utf8string(m_uri.host())))
+                        {
+                            return false;
+                        }
+                        else
+                        {
+                            return m_config.invoke_certificate_chain_callback(m_uri.host(), get_X509_cert_chain_encoded_data(verifyCtx));
+                        }
                     }
 #endif
                     boost::asio::ssl::rfc2818_verification rfc2818(utility::conversions::to_utf8string(m_uri.host()));
-                    return rfc2818(preverified, verifyCtx);
+                    if (!rfc2818(preverified, verifyCtx))
+                    {
+                        return false;
+                    }
+
+                    return m_config.invoke_certificate_chain_callback(m_uri.host(), get_X509_cert_chain_encoded_data(verifyCtx));
                 });
 
                 // OpenSSL stores some per thread state that never will be cleaned up until

--- a/Release/tests/functional/http/client/connections_and_errors.cpp
+++ b/Release/tests/functional/http/client/connections_and_errors.cpp
@@ -116,7 +116,7 @@ TEST_FIXTURE(uri_address, cert_pinning_succeed)
     client_config.set_credentials(cred);
     pplx::cancellation_token_source source;
 
-    client_config.set_user_certificate_pinning_callback([](const utility::string_t&, const utility::string_t&)->bool
+    client_config.set_user_certificate_chain_callback([](const utility::string_t&, const std::vector<std::vector<unsigned char>>&)->bool
     {
         // accept any certificate.
         return true;
@@ -126,6 +126,7 @@ TEST_FIXTURE(uri_address, cert_pinning_succeed)
 
     scoped.server()->next_request().then([&](test_request *p_request)
     {
+
         http_asserts::assert_test_request_equals(p_request, methods::GET, U("/"));
         p_request->reply(200);
     });
@@ -135,6 +136,7 @@ TEST_FIXTURE(uri_address, cert_pinning_succeed)
     VERIFY_ARE_EQUAL(status_codes::OK, response.status_code());
 }
 
+#ifndef _WIN32
 TEST_FIXTURE(uri_address, cert_pinning_failed)
 {
     test_http_server::scoped_server scoped(m_uri);
@@ -144,7 +146,7 @@ TEST_FIXTURE(uri_address, cert_pinning_failed)
     client_config.set_credentials(cred);
     pplx::cancellation_token_source source;
 
-    client_config.set_user_certificate_pinning_callback([](const utility::string_t&, const utility::string_t&)->bool
+    client_config.set_user_certificate_chain_callback([](const utility::string_t&, const std::vector<std::vector<unsigned char>>&)->bool
     {
         // don't accept any certificate.
         return false;
@@ -154,8 +156,9 @@ TEST_FIXTURE(uri_address, cert_pinning_failed)
 
     auto request = client.request(methods::GET, source.get_token());
 
-    VERIFY_THROWS_HTTP_ERROR_CODE(request.wait(), std::errc::operation_not_permitted);
+    VERIFY_THROWS_HTTP_ERROR_CODE(request.wait(), ERROR_WINHTTP_SECURE_FAILURE);
 }
+#endif
 
 TEST_FIXTURE(uri_address, server_close_without_responding)
 {


### PR DESCRIPTION
Changes to return the full cert chain back to the client by callback.
Passing the full cert chain will allow the client to do whatever they want to verify cert-pinning.